### PR TITLE
Updated service definition with uip (ip overrid) and ua (user agent over...

### DIFF
--- a/src/Krizon/Google/Analytics/MeasurementProtocol/Resources/service.php
+++ b/src/Krizon/Google/Analytics/MeasurementProtocol/Resources/service.php
@@ -4,7 +4,6 @@
  * This file is part of the php-ga-measurement-protocol package.
  *
  * (c) Kristian Zondervan <kristian.zondervan@gmail.com>
- * (c) Alexandre Assouad <alexandre.assouad@gmail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.


### PR DESCRIPTION
Hi, 
This is a pull request to reflect recent undocumented changes in google analytics measurement protocol.
(See this post on google groups : https://groups.google.com/d/msg/google-analytics-measurement-protocol/8TAp7_I1uTk/CIJtk3W3L-UJ  )

In case you want to forward google analytics request using a server, Google will always see your server ip and server http client user agent. To address these problems you can now use :
- The _uip_ parameters can be used to override ip address
- The _ua_ parameters can be used to override user agent

Hope you'll be interested in this pr !
