### PR TITLE
Migrate to guzzle4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
+  - 5.6
 
 before_script:
   - composer install --dev

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Easy use of the Google Analytics Measurement Protocol in PHP",
     "minimum-stability": "dev",
     "require": {
-        "guzzle/guzzle": "~3.7"
+        "guzzlehttp/guzzle-services": "0.3.*"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7.28"

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,9 @@
     "description": "Easy use of the Google Analytics Measurement Protocol in PHP",
     "minimum-stability": "dev",
     "require": {
-        "guzzlehttp/guzzle-services": "0.3.*"
+        "php": ">=5.4.0",
+        "guzzlehttp/guzzle-services": "~0.3",
+        "guzzlehttp/guzzle": "~4.2"
     },
     "require-dev": {
         "phpunit/phpunit": ">=3.7.28"

--- a/src/Krizon/Google/Analytics/MeasurementProtocol/MeasurementProtocolClient.php
+++ b/src/Krizon/Google/Analytics/MeasurementProtocol/MeasurementProtocolClient.php
@@ -11,38 +11,36 @@
 
 namespace Krizon\Google\Analytics\MeasurementProtocol;
 
-use Guzzle\Common\Collection;
-use Guzzle\Http\Message\Request;
-use Guzzle\Service\Client;
-use Guzzle\Service\Description\ServiceDescription;
+use GuzzleHttp\Client;
+use GuzzleHttp\Command\Guzzle\Description;
+use GuzzleHttp\Command\Guzzle\GuzzleClient;
+use GuzzleHttp\Command\Event\PrepareEvent;
 
-class MeasurementProtocolClient extends Client
+class MeasurementProtocolClient extends GuzzleClient
 {
+    const BASE_URL = 'http://www.google-analytics.com';
+    const BASE_URL_SSL = 'https://ssl.google-analytics.com';
+
     public static function factory($config = array())
     {
-        $default = array(
+        $config = array_merge(array(
             'ssl' => false,
             'tid' => null
-        );
-        $required = array('ssl');
+        ), $config);
 
-        $config = Collection::fromConfig($config, $default, $required);
+        $description = include __DIR__ . '/Resources/service.php';
+        $description['baseUrl'] = ($config['ssl'] === true) ? self::BASE_URL_SSL : self::BASE_URL;
 
-        $baseUrl = ($config->get('ssl') === true) ? 'https://ssl.google-analytics.com' : 'http://www.google-analytics.com';
+        $client = new Client($config);
+        $description = new Description($description);
+        $guzzleClient = new self($client, $description, $config);
 
-        $client = new self($baseUrl, $config);
-
-        $description = ServiceDescription::factory(__DIR__ . '/Resources/service.php');
-        $client->setDescription($description);
-
-        if (true === isset($config['tid'])) {
-            $client->getEventDispatcher()->addListener('command.before_prepare', function (\Guzzle\Common\Event $e) use($config) {
-                if (false === $e['command']->hasKey('tid')) {
-                    $e['command']->set('tid', $config['tid']);
-                }
-            });
-        }
-
-        return $client;
+        $guzzleClient->getEmitter()->on('prepare', function(PrepareEvent $event) use($config) {
+            $command = $event->getCommand();
+            if (false === $command->hasParam('tid')) {
+                $command['tid'] = $config['tid'];
+            }
+        }, 10);
+        return $guzzleClient;
     }
 }

--- a/src/Krizon/Google/Analytics/MeasurementProtocol/MeasurementProtocolClient.php
+++ b/src/Krizon/Google/Analytics/MeasurementProtocol/MeasurementProtocolClient.php
@@ -21,7 +21,7 @@ class MeasurementProtocolClient extends GuzzleClient
     const BASE_URL = 'http://www.google-analytics.com';
     const BASE_URL_SSL = 'https://ssl.google-analytics.com';
 
-    public static function factory($config = array())
+    public static function factory(array $config = array())
     {
         $config = array_merge(array(
             'ssl' => false,
@@ -31,16 +31,18 @@ class MeasurementProtocolClient extends GuzzleClient
         $description = include __DIR__ . '/Resources/service.php';
         $description['baseUrl'] = ($config['ssl'] === true) ? self::BASE_URL_SSL : self::BASE_URL;
 
-        $client = new Client($config);
+        $httpClient = new Client($config);
         $description = new Description($description);
-        $guzzleClient = new self($client, $description, $config);
+        $client = new self($httpClient, $description, $config);
 
-        $guzzleClient->getEmitter()->on('prepare', function(PrepareEvent $event) use($config) {
-            $command = $event->getCommand();
-            if (false === $command->hasParam('tid')) {
-                $command['tid'] = $config['tid'];
-            }
-        }, 10);
-        return $guzzleClient;
+        if (true === isset($config['tid'])) {
+            $client->getEmitter()->on('prepare', function(PrepareEvent $event) use($config) {
+                $command = $event->getCommand();
+                if (false === $command->hasParam('tid')) {
+                    $command['tid'] = $config['tid'];
+                }
+            }, 10);
+        }
+        return $client;
     }
 }

--- a/tests/Krizon/Google/Analytics/MeasurementProtocol/Test/MeasurementProtocolClientTest.php
+++ b/tests/Krizon/Google/Analytics/MeasurementProtocol/Test/MeasurementProtocolClientTest.php
@@ -11,17 +11,15 @@
 
 namespace Krizon\Google\Analytics\MeasurementProtocol\Test;
 
-use Guzzle\Http\Message\Response;
-use Guzzle\Plugin\History\HistoryPlugin;
-use Guzzle\Plugin\Mock\MockPlugin;
-use Guzzle\Service\Exception\ValidationException;
-use Guzzle\Tests\GuzzleTestCase;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Subscriber\History;
+use GuzzleHttp\Subscriber\Mock;
 use Krizon\Google\Analytics\MeasurementProtocol\MeasurementProtocolClient;
 
-class MeasurementProtocolClientTest extends GuzzleTestCase
+class MeasurementProtocolClientTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var null|HistoryPlugin
+     * @var null|History
      */
     private $history = null;
 
@@ -29,7 +27,7 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
     {
         $client = MeasurementProtocolClient::factory();
         $this->assertInstanceOf('Krizon\Google\Analytics\MeasurementProtocol\MeasurementProtocolClient', $client);
-        $this->assertEquals('http://www.google-analytics.com', $client->getBaseUrl());
+        $this->assertEquals('http://www.google-analytics.com', $client->getDescription()->getBaseUrl());
         $this->assertFalse($client->getConfig('ssl'));
     }
 
@@ -38,7 +36,7 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
         $client = MeasurementProtocolClient::factory(array(
             'ssl' => true
         ));
-        $this->assertEquals('https://ssl.google-analytics.com', $client->getBaseUrl());
+        $this->assertEquals('https://ssl.google-analytics.com', $client->getDescription()->getBaseUrl());
         $this->assertTrue($client->getConfig('ssl'));
     }
 
@@ -53,13 +51,9 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
 
     public function testAbstractCollectRequiredFields()
     {
-        try {
-            $this->getResponse('abstract.collect', array(), true);
-        } catch (ValidationException $e) {
-            $this->assertInstanceOf('Guzzle\Service\Exception\ValidationException', $e);
-            $this->assertSame('Validation errors: [tid] is required
-[cid] is required', $e->getMessage());
-        }
+        $this->setExpectedException('GuzzleHttp\Command\Exception\CommandException', 'Validation errors: [tid] is required
+[cid] is required');
+        $this->getResponse('abstract.collect', array(), true);
     }
 
     public function testPageview($mockResponse = true)
@@ -253,7 +247,6 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
             'cid' => $this->getCustomerId(),
         ), true, MeasurementProtocolClient::factory(array('tid' => 'X2')));
         $this->assertEquals('X2', $this->history->getLastRequest()->getQuery()->get('tid'));
-
     }
 
     public function testTrackingIdAsParam()
@@ -274,11 +267,9 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
         $this->assertEquals('X3', $this->history->getLastRequest()->getQuery()->get('tid'));
     }
 
-    /**
-     * @expectedException \Guzzle\Http\Exception\ServerErrorResponseException
-     */
     public function testBadGatewayTriggersException()
     {
+        $this->setExpectedException('GuzzleHttp\Command\Exception\CommandServerException');
         $this->getResponse('abstract.collect', array(
             'cid' => $this->getCustomerId(),
         ), true,  MeasurementProtocolClient::factory(array('tid' => 'BDGW')), 502);
@@ -309,22 +300,21 @@ class MeasurementProtocolClientTest extends GuzzleTestCase
     protected function getResponse($operation, array $parameters, $mockResponse = true, MeasurementProtocolClient $client = null, $statusCode = 200)
     {
         if (null === $client) {
-            $client = $this->getServiceBuilder()->get('ga_measurement_protocol');
+            $client = MeasurementProtocolClient::factory();
         }
 
         if (true === $mockResponse) {
-            $mock = new MockPlugin(array(new Response($statusCode)), true);
-            $client->addSubscriber($mock);
+            $mock = new Mock(array(new Response($statusCode)), true);
+            $client->getHttpClient()->getEmitter()->attach($mock);
         }
 
-        $history = new HistoryPlugin();
-        $history->setLimit(3);
-        $client->addSubscriber($history);
+        $history = new History(3);
+        $client->getHttpClient()->getEmitter()->attach($history);
         $this->history = $history;
 
-        $return = call_user_func(array($client, $operation), $parameters);
+        call_user_func(array($client, $operation), $parameters);
 
-        return $return;
+        return $history->getLastResponse();
     }
 
     protected function getTrackingId()

--- a/tests/Krizon/Google/Analytics/MeasurementProtocol/Test/MeasurementProtocolClientTest.php
+++ b/tests/Krizon/Google/Analytics/MeasurementProtocol/Test/MeasurementProtocolClientTest.php
@@ -280,14 +280,18 @@ class MeasurementProtocolClientTest extends \PHPUnit_Framework_TestCase
         $proxy = 'tcp://localhost:80';
         $client = MeasurementProtocolClient::factory(array(
             'tid' => $this->getTrackingId(),
-            'curl.options' => array(
-                'CURLOPT_PROXY'   => $proxy
+            'defaults' => array(
+                'config' => array(
+                    'curl' => array(
+                        CURLOPT_PROXY => $proxy
+                    )
+                )
             )
         ));
         $this->getResponse('abstract.collect', array(
             'cid' => $this->getCustomerId(),
         ), true, $client);
-        $requestCurlOptions = $this->history->getLastRequest()->getCurlOptions();
+        $requestCurlOptions = $this->history->getLastRequest()->getConfig()['curl'];
         $this->assertSame($proxy, $requestCurlOptions[CURLOPT_PROXY]);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -15,11 +15,3 @@ if (!file_exists(dirname(__DIR__) . '/composer.lock')) {
 }
 
 $loader = require dirname(__DIR__) . '/vendor/autoload.php';
-
-Guzzle\Tests\GuzzleTestCase::setServiceBuilder(Guzzle\Service\Builder\ServiceBuilder::factory(array(
-    'ga_measurement_protocol' => array(
-        'class' => 'Krizon\Google\Analytics\MeasurementProtocol\MeasurementProtocolClient',
-        'params' => array(
-        )
-    )
-)));


### PR DESCRIPTION
Rewrited client and tests for Guzzle4 compatibility. But because Guzzle4 not compatible with PHP 5.3, client not compatible too.

@krizon if you agree this PR, i recommend to create new release with last changes before merge.
